### PR TITLE
Make sure conditions get pointed at the right target

### DIFF
--- a/RaceCompatibilityDialogue/Program.cs
+++ b/RaceCompatibilityDialogue/Program.cs
@@ -168,7 +168,7 @@ namespace RaceCompatibilityDialogue
             var newData = new HasKeywordConditionData();
             newData.Keyword.Link.SetTo(targetRaceKeyword);
             newData.Reference.SetTo(character);
-            newData.RunOnType = Condition.RunOnType.Reference;
+            newData.RunOnType = character == Constants.Player ? Condition.RunOnType.Reference : condition.Data.RunOnType;
 
             newCondition.Data = newData;
 


### PR DESCRIPTION
I think this resolves #14

GetPCIsRace checks get converted to [PlayerRef].HasKeyword, everything else copies the target from the original condition.